### PR TITLE
Fix: Correct access to Preset object in getControl()

### DIFF
--- a/Anonymi/Anonymi.py
+++ b/Anonymi/Anonymi.py
@@ -523,7 +523,8 @@ class AnonymiLogic(ScriptedLoadableModuleLogic):
 
     outputTransform = slicer.vtkMRMLTransformNode()
 
-    parameterFilenames = elastix_logic.getRegistrationPresets()[0][5] # 5 = RegistrationPresets_ParameterFilenames
+    preset = elastix_logic.getRegistrationPresets()[0]
+    parameterFilenames = preset.getParameterFiles()
     elastix_logic.registerVolumes(inputVolume, template_mri_node,
                                   parameterFilenames=parameterFilenames,
                                   outputVolumeNode=outputVolume,


### PR DESCRIPTION
This PR fixes a TypeError that occurs when attempting to access a Preset object as if it were a subscriptable list in Anonymi.py.

The issue is described in detail in the related issue: #3 